### PR TITLE
clear entity cache on rollback

### DIFF
--- a/CypherNet.IntegrationTests/IntegrationTests.cs
+++ b/CypherNet.IntegrationTests/IntegrationTests.cs
@@ -577,5 +577,55 @@
                 Assert.AreEqual(nodes.Last().x.Id, james.Id);
             }
         }
+
+        [TestMethod]
+        public void UpdateCompleteTransaction_UpdateIsPersisted()
+        {
+            var clientFactory = Fluently.Configure("http://localhost:7474/db/data/").CreateSessionFactory();
+            var endpoint = clientFactory.Create();
+
+            const int originalValue = 100;
+            const int newValue = 200;
+
+            var personNode = endpoint.CreateNode(new { name = "Plzensky Prazdroj", age = originalValue });
+
+            using (var transaction = new TransactionScope())
+            {
+                dynamic node = endpoint.GetNode(personNode.Id);
+
+                node.age = newValue;
+                endpoint.Save(node);
+
+                transaction.Complete();
+
+            }
+
+            dynamic actualPerson = endpoint.GetNode(personNode.Id);
+            Assert.AreEqual(newValue, actualPerson.age);
+        }
+
+        [TestMethod]
+        public void UpdateRollback_EnsureEverythingIsRolledBack()
+        {
+            var clientFactory = Fluently.Configure("http://localhost:7474/db/data/").CreateSessionFactory();
+            var endpoint = clientFactory.Create();
+
+            const int originalValue = 100;
+            const int newValue = 200;
+
+            var personNode = endpoint.CreateNode(new { name = "Plzensky Prazdroj", age = originalValue });
+
+            using (var transaction = new TransactionScope())
+            {
+                dynamic node = endpoint.GetNode(personNode.Id);
+
+                node.age = newValue;
+                endpoint.Save(node);
+
+            }
+
+            dynamic actualPerson = endpoint.GetNode(personNode.Id);
+            Assert.AreEqual(originalValue, actualPerson.age);
+        }
     }
 }

--- a/CypherNet.UnitTests/CypherQueryTests.cs
+++ b/CypherNet.UnitTests/CypherQueryTests.cs
@@ -216,13 +216,13 @@
             var results = query
                 .Start(ctx => ctx.StartAtId(ctx.Vars.actor, 1))
                 .Match(ctx => ctx.Node(ctx.Vars.actor).Outgoing("STARED_IN", 0).To(ctx.Vars.movie))
-                ////.Where(ctx => ctx.Not(ctx.Node(ctx.Vars.movie).Outgoing("DIRECTED").To(ctx.Vars.director)))
-                .Where(ctx => ctx.Clause("not movie-[:DIRECTED]->director"))
+                ////.Where(ctx => ctx.Not(ctx.Node(ctx.Vars.movie).Outgoing("DIRECTED_BY").To(ctx.Vars.director)))
+                .Where(ctx => ctx.Clause("not movie-[:DIRECTED_BY]->director"))
                 .Return(ctx => ctx.Vars.movie)
                 .Fetch();
 
             VerifyCypher(cypher, results.FirstOrDefault(),
-                         "START actor=node(1) MATCH (actor)-[:STARED_IN*0..]->(movie) WHERE not movie-[:DIRECTED]->director RETURN movie as movie, id(movie) as movie__Id, labels(movie) as movie__Labels");
+                         "START actor=node(1) MATCH (actor)-[:STARED_IN*0..]->(movie) WHERE not movie-[:DIRECTED_BY]->director RETURN movie as movie, id(movie) as movie__Id, labels(movie) as movie__Labels");
         }
 
         [TestMethod]

--- a/CypherNet/Transaction/CypherClientFactory.cs
+++ b/CypherNet/Transaction/CypherClientFactory.cs
@@ -25,12 +25,14 @@ namespace CypherNet.Transaction
         private readonly string _baseUri;
         private readonly IWebClient _webClient;
         private readonly IWebSerializer _serializer;
+        private readonly IEntityCache _entityCache;
 
-        public CypherClientFactory(string baseUri, IWebClient webClient, IWebSerializer serializer)
+        public CypherClientFactory(string baseUri, IWebClient webClient, IWebSerializer serializer, IEntityCache entityCache)
         {
-            _baseUri = baseUri;
-            _webClient = webClient;
-            _serializer = serializer;
+            this._baseUri = baseUri;
+            this._webClient = webClient;
+            this._serializer = serializer;
+            this._entityCache = entityCache;
         }
 
         public ICypherClient Create()
@@ -47,7 +49,7 @@ namespace CypherNet.Transaction
                     }
                     else
                     {
-                        client = new TransactionalCypherClient(_baseUri, _webClient, _serializer);
+                        client = new TransactionalCypherClient(_baseUri, _webClient, _serializer, this._entityCache);
                         var notifier = new ResourceManager((ICypherUnitOfWork) client);
 
                         notifier.Complete += (o, e) =>

--- a/CypherNet/Transaction/CypherSession.cs
+++ b/CypherNet/Transaction/CypherSession.cs
@@ -105,13 +105,13 @@
 
         public ICypherQueryStart<TVariables> BeginQuery<TVariables>()
         {
-            return new FluentCypherQueryBuilder<TVariables>(new CypherClientFactory(_uri, _webClient, _webSerializer));
+            return new FluentCypherQueryBuilder<TVariables>(new CypherClientFactory(_uri, _webClient, _webSerializer, _entityCache));
         }
 
         public ICypherQueryStart<TVariables> BeginQuery<TVariables>(
             Expression<Func<ICypherPrototype, TVariables>> variablePrototype)
         {
-            return new FluentCypherQueryBuilder<TVariables>(new CypherClientFactory(_uri, _webClient, _webSerializer));
+            return new FluentCypherQueryBuilder<TVariables>(new CypherClientFactory(_uri, _webClient, _webSerializer, _entityCache));
         }
 
         public Node CreateNode(object properties)
@@ -131,7 +131,7 @@
                 propNames.PropertiesPropertyName,
                 propNames.IdPropertyName,
                 propNames.LabelsPropertyName);
-            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer).Create();
+            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer, _entityCache).Create();
             var result = endpoint.ExecuteQuery<SingleNodeResult>(clause);
             var node = result.First().NewNode;
             return node;
@@ -201,28 +201,28 @@
         public void CreateConstraint(string label, string property)
         {
             var clause = string.Format(CreateConstraintClauseFormat, NodeVariableName, label, property);
-            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer).Create();
+            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer, _entityCache).Create();
             endpoint.ExecuteCommand(clause);
         }
 
         public void DropConstraint(string label, string property)
         {
             var clause = string.Format(DropConstraintClauseFormat, NodeVariableName, label, property);
-            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer).Create();
+            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer, _entityCache).Create();
             endpoint.ExecuteCommand(clause);
         }
 
         public void CreateIndex(string label, string property)
         {
             var clause = string.Format(CreateIndexClauseFormat, label, property);
-            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer).Create();
+            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer, _entityCache).Create();
             endpoint.ExecuteCommand(clause);
         }
 
         public void DropIndex(string label, string property)
         {
             var clause = string.Format(DropIndexClauseFormat, label, property);
-            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer).Create();
+            var endpoint = new CypherClientFactory(_uri, _webClient, _webSerializer, _entityCache).Create();
             endpoint.ExecuteCommand(clause);
         }
 


### PR DESCRIPTION
updated entities where persisting in the cache after a rollback so that
incorrect results are returned from queries
