### PR TITLE
Allow to customize the JsonSerializer using json converters

### DIFF
--- a/CypherNet/ICypherSession.cs
+++ b/CypherNet/ICypherSession.cs
@@ -6,6 +6,7 @@
     using System.Linq.Expressions;
     using Graph;
     using Queries;
+    using Newtonsoft.Json;
 
     #endregion
 
@@ -29,6 +30,8 @@
 
         void CreateIndex(string label, string property);
         void DropIndex(string label, string property);
+
+        JsonConverterCollection JsonConverters { get; }
 
         void Clear();
 

--- a/CypherNet/Serialization/DefaultJsonSerializer.cs
+++ b/CypherNet/Serialization/DefaultJsonSerializer.cs
@@ -21,6 +21,8 @@
 
         #region IJsonSerializer Members
 
+        public JsonConverterCollection JsonConverters { get { return _serializer.Converters; } }
+
         public string Serialize(object objToSerialize)
         {
             var sw = new StringWriter();

--- a/CypherNet/Serialization/IJsonSerializer.cs
+++ b/CypherNet/Serialization/IJsonSerializer.cs
@@ -1,7 +1,10 @@
-﻿namespace CypherNet.Serialization
+﻿using Newtonsoft.Json;
+
+namespace CypherNet.Serialization
 {
     public interface IWebSerializer
     {
+        JsonConverterCollection JsonConverters { get; }
         string Serialize(object objToSerialize);
         TItem Deserialize<TItem>(string json);
     }

--- a/CypherNet/Transaction/CypherSession.cs
+++ b/CypherNet/Transaction/CypherSession.cs
@@ -16,6 +16,7 @@
     using CypherNet.Serialization;
 
     using StaticReflection;
+    using Newtonsoft.Json;
 
     #endregion
 
@@ -39,6 +40,7 @@
         private readonly IWebSerializer _webSerializer;
         private readonly IEntityCache _entityCache;
         private readonly IWebClient _webClient;
+        public JsonConverterCollection JsonConverters { get { return _webSerializer.JsonConverters; } }
 
         internal CypherSession(string uri)
             : this(uri, new WebClient())


### PR DESCRIPTION
   Allow to customize the jsonSerializer, for example:


>            var cypherSessionFactory = Fluently.Configure(_uriString).CreateSessionFactory();
>            var cypherSession = cypherSessionFactory.Create();
>            cypherSession.JsonConverters.Add(new CustomJsonConverter());

>            ...
