### PR TITLE
Fixed error while creating relationships with properties, updated package to support Exists clause instead of Has

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,3 @@ UpgradeLog*.XML
 
 # Nuget Files
 *.nupkg
-*.nuspec

--- a/CypherNet.IntegrationTests/IntegrationTests.cs
+++ b/CypherNet.IntegrationTests/IntegrationTests.cs
@@ -127,7 +127,7 @@
 
             var newNode1 = endpoint.CreateNode(new { name = "mark", age = 33 }, "person");
             var newNode2 = endpoint.CreateNode(new { role = "developer" }, "job");
-            var rel = endpoint.CreateRelationship(newNode1, newNode2, "WORKS_AS_A", new { created = DateTime.Now.ToString("s") });
+            var rel = endpoint.CreateRelationship(newNode1, newNode2, "WORKS_AS_A", new { created = DateTime.Now.ToString("s"), salary = 1000.5 });
             Assert.IsNotNull(rel);
             Assert.AreEqual("WORKS_AS_A", rel.Type);
         }
@@ -534,7 +534,7 @@
 
                 var nodes = endpoint.BeginQuery(p => new { node = p.Node })
                                           .Start(ctx => ctx.StartAtAny(ctx.Vars.node))
-                                          .Where(ctx => ctx.Has(ctx.Vars.node, "firstname"))
+                                          .Where(ctx => ctx.Exists(ctx.Vars.node, "firstname"))
                                           .Return(ctx => new { Node = ctx.Vars.node })
                                           .Fetch();
                 Assert.AreEqual(1, nodes.Count());
@@ -554,7 +554,7 @@
 
                 var nodes = endpoint.BeginQuery(p => new { node = p.Node })
                                           .Start(ctx => ctx.StartAtAny(ctx.Vars.node))
-                                          .Where(ctx => ctx.Has(ctx.Vars.node, "xxxxx"))
+                                          .Where(ctx => ctx.Exists(ctx.Vars.node, "xxxxx"))
                                           .Return(ctx => new { Node = ctx.Vars.node })
                                           .Fetch();
                 Assert.AreEqual(0, nodes.Count());
@@ -586,8 +586,8 @@
                         .Fetch();
 
                 Assert.AreEqual(2, nodes.Count());
-                Assert.AreEqual(nodes.First().x.Id, frank.Id);
-                Assert.AreEqual(nodes.Last().x.Id, james.Id);
+                Assert.IsTrue(nodes.Any(n => n.x.Id == frank.Id));
+                Assert.IsTrue(nodes.Any(n => n.x.Id == james.Id));
             }
         }
 

--- a/CypherNet.UnitTests/CypherQueryTests.cs
+++ b/CypherNet.UnitTests/CypherQueryTests.cs
@@ -152,7 +152,24 @@
                 .Fetch();
 
             VerifyCypher(cypher, results.FirstOrDefault(),
-                         @"START actor=node(1), movie=node(2) CREATE (actor)-[actedIn:ACTED_IN {""name"": ""mark""}]->(movie) RETURN actedIn as actedIn, id(actedIn) as actedIn__Id, type(actedIn) as actedIn__Type");
+                         @"START actor=node(1), movie=node(2) CREATE (actor)-[actedIn:ACTED_IN {name:""mark""}]->(movie) RETURN actedIn as actedIn, id(actedIn) as actedIn__Id, type(actedIn) as actedIn__Type");
+        }
+
+        [TestMethod]
+        public void BuildCypherQuery_CreateRelationshipWithFloatProperty_SerializesValueWithDotNotComma()
+        {
+            FluentCypherQueryBuilder<TestCypherClause> query;
+            var cypher = SetupMocks(out query);
+            var results = query
+                .Start(ctx => ctx
+                    .StartAtId(ctx.Vars.actor, 1)
+                    .StartAtId(ctx.Vars.movie, 2))
+                .Create(ctx => ctx.CreateRel(ctx.Vars.actor, ctx.Vars.actedIn, "HAS_RATE", new { rate = 4.56 }, ctx.Vars.movie))
+                .Return(ctx => new { ctx.Vars.actedIn })
+                .Fetch();
+
+            VerifyCypher(cypher, results.FirstOrDefault(), 
+                @"START actor=node(1), movie=node(2) CREATE (actor)-[actedIn:HAS_RATE {rate:4.56}]->(movie) RETURN actedIn as actedIn, id(actedIn) as actedIn__Id, type(actedIn) as actedIn__Type");
         }
 
         [TestMethod]

--- a/CypherNet.sln.DotSettings
+++ b/CypherNet.sln.DotSettings
@@ -1,5 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">200</s:Int64>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/CypherNet/Configuration/CypherJsonSerializerSettings.cs
+++ b/CypherNet/Configuration/CypherJsonSerializerSettings.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace CypherNet.Configuration
+{
+    public static class CypherJsonSerializerSettings
+    {
+        public static Func<JsonSerializerSettings> DefaultSerializerSettings { get; set; }
+
+        static CypherJsonSerializerSettings()
+        {
+            DefaultSerializerSettings = () => new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            };
+        }
+    }
+}

--- a/CypherNet/CypherNet.csproj
+++ b/CypherNet/CypherNet.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\CypherJsonSerializerSettings.cs" />
     <Compile Include="Configuration\Fluently.cs" />
     <Compile Include="Configuration\Neo4JConnectionStringParser.cs" />
     <Compile Include="Dynamic\CachedDictionaryPropertiesProvider.cs" />

--- a/CypherNet/CypherNet.nuspec
+++ b/CypherNet/CypherNet.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+    <projectUrl>https://github.com/mtranter/CypherNet</projectUrl>    
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes>Update to support basic auth</releaseNotes>
+	<tags>Neo4j Cypher</tags>
+    <copyright>Copyright 2013</copyright>    
+  </metadata>
+</package>

--- a/CypherNet/Properties/AssemblyInfo.cs
+++ b/CypherNet/Properties/AssemblyInfo.cs
@@ -40,7 +40,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.9.2.7")]
-[assembly: AssemblyFileVersion("0.9.2.7")]
+[assembly: AssemblyVersion("0.9.8.1")]
+[assembly: AssemblyFileVersion("0.9.8.1")]
 [assembly: InternalsVisibleTo("CypherNet.UnitTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/CypherNet/Queries/IQueryContext.cs
+++ b/CypherNet/Queries/IQueryContext.cs
@@ -1,4 +1,6 @@
-﻿namespace CypherNet.Queries
+﻿using System;
+
+namespace CypherNet.Queries
 {
     using CypherNet.Graph;
 
@@ -28,8 +30,14 @@
             [ArgumentEvaluator(typeof(MemberNameArgumentEvaluator))] IGraphEntity entity,
             [ArgumentEvaluator(typeof(ValueArgumentEvaluator))] string property);
 
+        [Obsolete("Has is no longer supported in Cypher from version 3.0, please use Exists instead")]
         [ParseToCypher("has({0}.{1})")]
         bool Has(
+            [ArgumentEvaluator(typeof(MemberNameArgumentEvaluator))] IGraphEntity entity,
+            [ArgumentEvaluator(typeof(ValueArgumentEvaluator))] string property);
+
+        [ParseToCypher("exists({0}.{1})")]
+        bool Exists(
             [ArgumentEvaluator(typeof(MemberNameArgumentEvaluator))] IGraphEntity entity,
             [ArgumentEvaluator(typeof(ValueArgumentEvaluator))] string property);
 

--- a/CypherNet/Serialization/DefaultJsonSerializer.cs
+++ b/CypherNet/Serialization/DefaultJsonSerializer.cs
@@ -6,6 +6,7 @@
     using System.IO;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
+    using CypherNet.Configuration;
 
     #endregion
 
@@ -15,7 +16,7 @@
 
         internal DefaultJsonSerializer(IEntityCache cache)
         {
-            _serializer = new JsonSerializer { NullValueHandling = NullValueHandling.Ignore };
+            _serializer = JsonSerializer.Create(CypherJsonSerializerSettings.DefaultSerializerSettings?.Invoke());
             _serializer.Converters.Insert(0, new CypherResultSetConverterFactoryJsonConverter(cache));
         }
 

--- a/CypherNet/Transaction/NonTransactionalCypherClient.cs
+++ b/CypherNet/Transaction/NonTransactionalCypherClient.cs
@@ -29,6 +29,7 @@ namespace CypherNet.Transaction
 
         public IEnumerable<TOut> ExecuteQuery<TOut>(string cypherQuery)
         {
+            
             var request = CypherQueryRequest.Create(cypherQuery);
             var srequest = _serializer.Serialize(request);
             Logger.Current.Log("Executing: " + srequest, LogLevel.Info);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 CypherNet
 =========
 
-[![Build status](https://ci.appveyor.com/api/projects/status/mtpg771qhljc3jai?svg=true)](https://ci.appveyor.com/project/mtranter/cyphernet)
+[![Build status](https://ci.appveyor.com/api/projects/status/5uv5y4x6xohbb5o3?svg=true)](https://ci.appveyor.com/project/mtranter/cyphernet-kv3k3)
+
 
 A .Net API for the Neo4j HTTP Transactional Endpoint. (v2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -8,23 +8,18 @@ A .Net API for the Neo4j HTTP Transactional Endpoint. (v2.0.0)
 
 Exposes strongly typed Graph Query API based on the Neo4j [Cypher Query Language](http://docs.neo4j.org/chunked/milestone/cypher-query-lang.html).
 
-<dl>
-    <dt>Connection String</dt>
-    <dd></dd>
-</dl>
+### Connection String
 ```C#
 var clientFactory = Fluently.Configure("Server=http://localhost:7474/db/data/;User Id=neo4j;Password=password").CreateSessionFactory();
 var cypherEndpoint = clientFactory.Create();
 ```
+
 or for Unauthd:
 ```C#
 var clientFactory = Fluently.Configure("http://localhost:7474/db/data/").CreateSessionFactory();
 var cypherEndpoint = clientFactory.Create();
 ```
-<dl>
-    <dt>Usage</dt>
-    <dd></dd>
-</dl>
+### Usage
 ```C#
 var clientFactory = Fluently.Configure("http://localhost:7474/db/data/").CreateSessionFactory();
 var cypherEndpoint = clientFactory.Create();
@@ -58,10 +53,8 @@ foreach (var node in nodes)
         // Prints "mark IS_A developer"
 }
 ```
-<dl>
-    <dt>Transactional</dt>
-    <dd></dd>
-</dl>
+
+### Transactional
 ```C#
 var clientFactory = Fluently.Configure("http://localhost:7474/db/data/").CreateSessionFactory();
 var cypherEndpoint = clientFactory.Create();

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 CypherNet
 =========
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/mtranter/CypherNet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 [![Build status](https://ci.appveyor.com/api/projects/status/mtpg771qhljc3jai?svg=true)](https://ci.appveyor.com/project/mtranter/cyphernet)
 
 A .Net API for the Neo4j HTTP Transactional Endpoint. (v2.0.0)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ build:
 deploy:
 - provider: NuGet
   api_key:
-    secure: TFTKac0CbCOvowsFmuUzFjjIcRNJNJnigSh568rlQcjSn2E3JjWbVcobqVD3wGtl
+    secure: UFKXWUd+DCrlU6Nd5vL2561QhzK/fqcroXixaOCMBdMzT1fWwhouWwmcGnZSPiyK
   skip_symbols: true
   on:
     branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 install:
-  - ps: Write-Host '$env:APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip'
-  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName '$env:APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip'
+  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName "$env:APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip"
   - cmd: 7z x %APPVEYOR_BUILD_FOLDER%\neo4j-community-2.3.2-windows.zip
   - ps: .\setup-neo4j.ps1
 version: 0.9.{build}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,4 @@ install:
   - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName 'c:\projects\CypherNet\neo4j-community-2.3.2-windows.zip'
   - cmd: 7z x c:\projects\CypherNet\neo4j-community-2.3.2-windows.zip
   - ps: .\setup-neo4j.ps1
-  
-build:
-  publish_nuget: true             # package projects with .nuspec files and push to artifacts
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,3 +3,9 @@ install:
   - cmd: 7z x c:\projects\CypherNet\neo4j-community-2.3.2-windows.zip
   - ps: .\setup-neo4j.ps1
 
+deploy:
+  provider: NuGet
+  api_key:
+    secure: TFTKac0CbCOvowsFmuUzFjjIcRNJNJnigSh568rlQcjSn2E3JjWbVcobqVD3wGtl
+  skip_symbols: true
+  artifact: /.*\.nupkg/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 install:
-  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName 'c:\projects\CypherNet\neo4j-community-2.3.2-windows.zip'
-  - cmd: 7z x c:\projects\CypherNet\neo4j-community-2.3.2-windows.zip
-  - ps: .\setup-neo4j.ps1
+  -
+  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName '$APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip'
+  - ps: 7z x $APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip
+  - ps: $APPVEYOR_BUILD_FOLDER\setup-neo4j.ps1
 version: 0.9.{build}
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 install:
+  - ps: Write-Host '$env:APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip'
   - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName '$env:APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip'
   - cmd: 7z x %APPVEYOR_BUILD_FOLDER%\neo4j-community-2.3.2-windows.zip
   - ps: .\setup-neo4j.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ install:
   - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName 'c:\projects\CypherNet\neo4j-community-2.3.2-windows.zip'
   - cmd: 7z x c:\projects\CypherNet\neo4j-community-2.3.2-windows.zip
   - ps: .\setup-neo4j.ps1
-
 version: 0.9.{build}
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,22 @@ install:
   - cmd: 7z x c:\projects\CypherNet\neo4j-community-2.3.2-windows.zip
   - ps: .\setup-neo4j.ps1
 
+version: 0.9.{build}
+pull_requests:
+  do_not_increment_build_number: true
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+build:
+  publish_nuget: true
+  verbosity: minimal
 deploy:
-  provider: NuGet
+- provider: NuGet
   api_key:
     secure: TFTKac0CbCOvowsFmuUzFjjIcRNJNJnigSh568rlQcjSn2E3JjWbVcobqVD3wGtl
   skip_symbols: true
-  artifact: /.*\.nupkg/
+  on:
+    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
 install:
-  -
-  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip'
-  - cmd: 7z x neo4j-community-2.3.2-windows.zip
-  - ps: setup-neo4j.ps1
+  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName '$env:APPVEYOR_BUILD_FOLDER/neo4j-community-2.3.2-windows.zip'
+  - cmd: 7z x %APPVEYOR_BUILD_FOLDER%\neo4j-community-2.3.2-windows.zip
+  - ps: .\setup-neo4j.ps1
 version: 0.9.{build}
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 install:
   -
-  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName '$APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip'
-  - ps: 7z x $APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip
-  - ps: $APPVEYOR_BUILD_FOLDER\setup-neo4j.ps1
+  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip'
+  - cmd: 7z x neo4j-community-2.3.2-windows.zip
+  - ps: setup-neo4j.ps1
 version: 0.9.{build}
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName '$env:APPVEYOR_BUILD_FOLDER/neo4j-community-2.3.2-windows.zip'
+  - ps: Start-FileDownload 'http://neo4j.com/artifact.php?name=neo4j-community-2.3.2-windows.zip' -FileName '$env:APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2-windows.zip'
   - cmd: 7z x %APPVEYOR_BUILD_FOLDER%\neo4j-community-2.3.2-windows.zip
   - ps: .\setup-neo4j.ps1
 version: 0.9.{build}

--- a/setup-neo4j.ps1
+++ b/setup-neo4j.ps1
@@ -1,4 +1,4 @@
-Import-Module "c:\projects\CypherNet\neo4j-community-2.3.2\bin\Neo4j-Management.psd1"
+Import-Module "$env:APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2\bin\Neo4j-Management.psd1"
 
 function update-password
 {
@@ -14,7 +14,7 @@ function update-password
   Invoke-RestMethod -Uri $uri -Method Post -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -ContentType "application/json; charset=UTF-8" -Body $json
 }
  
-Install-Neo4jServer -Neo4jServer "c:\projects\CypherNet\neo4j-community-2.3.2" -PassThru | Start-Neo4jServer
+Install-Neo4jServer -Neo4jServer "$env:APPVEYOR_BUILD_FOLDER\neo4j-community-2.3.2" -PassThru | Start-Neo4jServer
 
 Start-Sleep -s 10
 


### PR DESCRIPTION
Hello,

while creating relationship with properties I noticed that JsonArgumentEvaluator for floating point serializes float values with comma (`0,001`) instead of dot (`0.001`). This happens potentially because of my localization settings. I changed the code of `JsonArgumentEvaluator` to use `Newtonsoft.Json.JsonSerializer` instead of your homebrew json serialization. Serializer is using
custom json serialization settings which are obtained from new static class `CypherJsonSerializerSettings`. This class contains one property which has lambda returning `JsonSerializerSettings` instance. This lambda can be changed, which allows users to customize serializaton. 

Besides, I made `has` statement obsolete (as it is no longer supported in newer versions of Cypher and created `Exists` statement as it is replacement for `has`. 

Would be nice if you could review changes and merge this. 